### PR TITLE
Fix for setuptools installation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/twist_stamper
+script_dir=$base/lib/twist_stamper
 [install]
-install-scripts=$base/lib/twist_stamper
+install_scripts=$base/lib/twist_stamper


### PR DESCRIPTION
This fixes a bug when building the package as setuptools has had an update to use `script_dir` and  `install_scripts` with an underscore instead of a dash (`script-dir` and  `install-scripts`) now. Please see [here](https://answers.ros.org/question/386341/ros2-userwarning-usage-of-dash-separated-install-scripts-will-not-be-supported-in-future-versions-please-use-the-underscore-name-install_scripts/) for reference.