### PR TITLE
Fix deprecation warning in parameter

### DIFF
--- a/twist_stamper/twist_stamper.py
+++ b/twist_stamper/twist_stamper.py
@@ -25,8 +25,8 @@ class TwistStamper(Node):
     def __init__(self):
         super().__init__('twist_stamper')
 
-        self.declare_parameter("frame_id")
-        self.frame_id = self.get_parameter("frame_id").get_parameter_value().string_value
+        self.declare_parameter("frame_id", "")
+        self.frame_id = str(self.get_parameter("frame_id").value)
 
         self.publisher_ = self.create_publisher(TwistStamped, 'cmd_vel_out', 10)
 


### PR DESCRIPTION
This fixes the following deprecation warning:

```
[twist_stamper-7] /opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/node.py:441: UserWarning: when declaring parameter named 'frame_id', declaring a parameter only providing its name is deprecated. You have to either:
[twist_stamper-7] 	- Pass a name and a default value different to "PARAMETER NOT SET" (and optionally a descriptor).
[twist_stamper-7] 	- Pass a name and a parameter type.
[twist_stamper-7] 	- Pass a name and a descriptor with `dynamic_typing=True
```